### PR TITLE
HDDS-9305. ozone admin om roles --service-id improvement

### DIFF
--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test-omadmin.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test-omadmin.sh
@@ -19,12 +19,15 @@
 
 COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 export COMPOSE_DIR
+export SECURITY_ENABLED=false
+export SCM=scm1
+export OM_SERVICE_ID=omservice
 
 # shellcheck source=/dev/null
 source "$COMPOSE_DIR/../testlib.sh"
 
 start_docker_env
 
-execute_robot_test om1 kinit.robot
+execute_robot_test scm1 kinit.robot
 
-execute_robot_test om1 omha/om-roles.robot
+execute_robot_test scm1 omha/om-roles.robot

--- a/hadoop-ozone/dist/src/main/compose/ozone-ha/test-omadmin.sh
+++ b/hadoop-ozone/dist/src/main/compose/ozone-ha/test-omadmin.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#suite:HA-unsecure
+
+COMPOSE_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+export COMPOSE_DIR
+
+# shellcheck source=/dev/null
+source "$COMPOSE_DIR/../testlib.sh"
+
+start_docker_env
+
+execute_robot_test om1 kinit.robot
+
+execute_robot_test om1 omha/om-roles.robot

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -21,10 +21,15 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 
 *** Test Cases ***
 List om roles
-    ${output} =         Execute          ozone admin om roles --service-id=omservice
-                        Should Match Regexp   ${output}  [om (: LEADER|)]
+    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice
+                                    Should Match Regexp   ${output_with_id_passed}  [om (: LEADER|)]
+    ${output_without_id_passed} =   Execute          ozone admin om roles
+                                    Should Match Regexp   ${output_without_id_passed}  [om (: LEADER|)]
 
 List om roles as JSON
-    ${output} =         Execute          ozone admin om roles --service-id=omservice --json
-    ${leader} =         Execute          echo '${output}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                        Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice --json
+    ${leader} =                     Execute          echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_without_id_passed} =   Execute          ozone admin om roles
+    ${leader} =                     Execute          echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal       ${leader}       ${EMPTY}

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -21,15 +21,15 @@ Test Setup          Run Keyword if    '${SECURITY_ENABLED}' == 'true'    Kinit t
 
 *** Test Cases ***
 List om roles
-    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice
-                                    Should Match Regexp   ${output_with_id_passed}  [om (: LEADER|)]
-    ${output_without_id_passed} =   Execute          ozone admin om roles
-                                    Should Match Regexp   ${output_without_id_passed}  [om (: LEADER|)]
+    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice
+                                    Should Match Regexp     ${output_with_id_passed}  [om (: LEADER|)]
+    ${output_without_id_passed} =   Execute                 ozone admin om roles
+                                    Should Match Regexp     ${output_without_id_passed}  [om (: LEADER|)]
 
 List om roles as JSON
-    ${output_with_id_passed} =      Execute          ozone admin om roles --service-id=omservice --json
-    ${leader} =                     Execute          echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                                    Should Not Be Equal       ${leader}       ${EMPTY}
-    ${output_without_id_passed} =   Execute          ozone admin om roles
-    ${leader} =                     Execute          echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
-                                    Should Not Be Equal       ${leader}       ${EMPTY}
+    ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice --json
+    ${leader} =                     Execute                 echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal     ${leader}       ${EMPTY}
+    ${output_without_id_passed} =   Execute                 ozone admin om roles --json
+    ${leader} =                     Execute                 echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+                                    Should Not Be Equal     ${leader}       ${EMPTY}

--- a/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
+++ b/hadoop-ozone/dist/src/main/smoketest/omha/om-roles.robot
@@ -28,8 +28,8 @@ List om roles
 
 List om roles as JSON
     ${output_with_id_passed} =      Execute                 ozone admin om roles --service-id=omservice --json
-    ${leader} =                     Execute                 echo '${output_with_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+    ${leader} =                     Execute                 echo '${output_with_id_passed}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
                                     Should Not Be Equal     ${leader}       ${EMPTY}
     ${output_without_id_passed} =   Execute                 ozone admin om roles --json
-    ${leader} =                     Execute                 echo '${output_without_id_passed}' | jq -r '.[] | select(.serverRole == "LEADER")'
+    ${leader} =                     Execute                 echo '${output_without_id_passed}' | jq '.[] | select(.[] | .serverRole == "LEADER")'
                                     Should Not Be Equal     ${leader}       ${EMPTY}

--- a/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
+++ b/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/GetServiceRolesSubcommand.java
@@ -49,7 +49,7 @@ public class GetServiceRolesSubcommand implements Callable<Void> {
 
   @CommandLine.Option(names = {"-id", "--service-id"},
       description = "OM Service ID",
-      required = true)
+      required = false)
   private String omServiceId;
 
   @CommandLine.Option(names = { "--json" },


### PR DESCRIPTION
What changes were proposed in this pull request?
Currently, for ozone admin om roles command, we need to specify the om service ID as its a mandatory parameter.

bash-4.2$ ozone admin om roles
Missing required option: '--service-id=<omServiceId>'
Usage: ozone admin om roles [-hV] [--json] -id=<omServiceId>
List all OMs and their respective Ratis server roles
  -h, --help      Show this help message and exit.
      -id, --service-id=<omServiceId>
                  OM Service ID
      --json      Format output as JSON
  -V, --version   Print version information and exit.
Even if the omServiceId is null, its handled properly [here](https://github.com/apache/ozone/blob/4b43f158b8b5f9e0d1a58ffe81d3411729337c66/hadoop-ozone/tools/src/main/java/org/apache/hadoop/ozone/admin/om/OMAdmin.java#L113)

What is the link to the Apache JIRA
[HDDS-9305](https://issues.apache.org/jira/browse/HDDS-9305)

How was this patch tested?
Modified already present Robot tests.